### PR TITLE
Add handling for MLP read methods to wrapper

### DIFF
--- a/include/FluidPDWrapper.hpp
+++ b/include/FluidPDWrapper.hpp
@@ -1245,7 +1245,16 @@ private:
       }
       if (message.name == "read")
       {
-        SpecialCase<MessageResult<void>, std::string>{}.template handle<N>(
+        using ParamValues = typename ParamSetType::ValueTuple;
+        using ReturnType = typename T::ReturnType;
+        using ArgumentTypes = typename T::ArgumentTypes;
+        constexpr bool isVoid = std::is_same<ReturnType, MessageResult<void>>::value;
+        
+        using IfVoid = SpecialCase<MessageResult<void>,std::string>;
+        using IfParams = SpecialCase<MessageResult<ParamValues>,std::string>;
+        using Handler = std::conditional_t<isVoid, IfVoid, IfParams>;
+        
+        Handler{}.template handle<N>(
             typename T::ReturnType{}, typename T::ArgumentTypes{},
             [&message](auto M) {
               class_addmethod(getClass(), (t_method) doRead<decltype(M)::value>,


### PR DESCRIPTION
fix #9 

The wrapper still needed to be updated now that the `read` methods for MLP objects have a different signature