### PR TITLE
Nightly Continuous Integration

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -7,12 +7,12 @@ on:
 jobs:
 
   docs:
-      runs-on: ubuntu-18.04
+      runs-on: macos-11
       steps:
         - uses: actions/checkout@v2
 
         - name: install ninja
-          run: sudo apt update && sudo apt install ninja-build
+          run: brew install ninja
 
         - name: install python dependencies
           run: pip3 install pyyaml docutils jinja2

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -59,7 +59,7 @@ jobs:
         run: git clone --branch dev https://github.com/flucoma/flucoma-sc.git core   
         
       - name: cmake
-        run: cmake -DPD_PATH="../pd-0.51-4" -DFLUID_CORE="../core" ..
+        run: cmake -DPD_PATH="../pd-0.51-4" -DFLUID_PATH="../core" ..
         working-directory: build
         
       - name: install
@@ -90,7 +90,7 @@ jobs:
         run: git clone --branch dev https://github.com/flucoma/flucoma-sc.git core
         
       - name: cmake
-        run: cmake -DPD_PATH=../sdk -DFLUID_CORE=../core ..
+        run: cmake -DPD_PATH=../sdk -DFLUID_PATH=../core ..
         working-directory: build
         
       - name: install

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -129,7 +129,7 @@ jobs:
       - uses: dev-drprasad/delete-tag-and-release@v0.2.0
         with:
           delete_release: true
-          tag_name: 1.0.0-nightly
+          tag_name: nightly
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         
@@ -142,5 +142,5 @@ jobs:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: FluCoMa-PD-*.zip
           file_glob: true
-          tag: 1.0.0-nightly
+          tag: nightly
           overwrite: true

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -5,7 +5,6 @@ on:
     branches: [ dev, ci/nightlies ]
 
 jobs:
-  # Eventually this https://github.community/t/create-matrix-with-multiple-os-and-env-for-each-one/16895/5
   macbuild:
     runs-on: macos-11
 
@@ -48,6 +47,7 @@ jobs:
         run: Expand-Archive sdk.zip -DestinationPath ./ -Force
 
       - name: ls
+        run: ls
         
       - name: make build directory
         run: mkdir -p build

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -57,7 +57,7 @@ jobs:
         working-directory: build
         
       - name: install
-        run: cmake --build . --target install
+        run: cmake --build . --target install --config Release
         working-directory: build
 
       - name: remove pdb files

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -175,7 +175,7 @@ jobs:
         run: cp -r docs win
 
       - name: compress windows
-        run: zip -r ../FluCoMa-CLI-Windows-nightly.zip .
+        run: zip -r ../FluCoMa-PD-Windows-nightly.zip .
         working-directory: win
       
       #### UPLOAD RELEASE ####

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -19,7 +19,7 @@ jobs:
         run: mkdir -p build
         
       - name: cmake
-        run: cmake -DSC_PATH=../sdk ..
+        run: cmake -DPD_PATH=../sdk ..
         working-directory: build
         
       - name: install
@@ -48,7 +48,7 @@ jobs:
         run: mkdir -p build
         
       - name: cmake
-        run: cmake -DSC_PATH="../sdk" ..
+        run: cmake -DPD_PATH="../sdk" ..
         working-directory: build
         
       - name: install
@@ -79,7 +79,7 @@ jobs:
         run: mkdir -p build
         
       - name: cmake
-        run: cmake -DSC_PATH=../sdk ..
+        run: cmake -DPD_PATH=../sdk ..
         working-directory: build
         
       - name: install
@@ -121,9 +121,9 @@ jobs:
       - name: package and upload
         uses: svenstaro/upload-release-action@v2
         with:
-          release_name: FluCoMa Max Nightly Build
+          release_name: FluCoMa PureData Nightly Build
           prerelease: true
-          body: "This is a nightly build of the FluCoMa Max package. As such, be warned there may be bugs or other unexpected behaviour. The build hash is ${{ github.sha }}"
+          body: "This is a nightly build of the FluCoMa PureData package. As such, be warned there may be bugs or other unexpected behaviour. The build hash is ${{ github.sha }}"
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: FluCoMa-PD-*.zip
           file_glob: true

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -18,7 +18,7 @@ jobs:
         run: mkdir -p build
 
       - name: clone latest flucoma-core
-        run: git clone --branch dev https://github.com/flucoma/flucoma-sc.git core   
+        run: git clone --branch dev https://github.com/flucoma/flucoma-core.git core   
         
       - name: cmake
         run: cmake -DPD_PATH=../sdk -DFLUID_PATH=../core ..
@@ -56,7 +56,7 @@ jobs:
         run: mkdir -p build
 
       - name: clone latest flucoma-core
-        run: git clone --branch dev https://github.com/flucoma/flucoma-sc.git core   
+        run: git clone --branch dev https://github.com/flucoma/flucoma-core.git core   
         
       - name: cmake
         run: cmake -DPD_PATH="../pd-0.51-4" -DFLUID_PATH="../core" ..
@@ -87,7 +87,7 @@ jobs:
         run: mkdir -p build
 
       - name: clone latest flucoma-core
-        run: git clone --branch dev https://github.com/flucoma/flucoma-sc.git core
+        run: git clone --branch dev https://github.com/flucoma/flucoma-core.git core
         
       - name: cmake
         run: cmake -DPD_PATH=../sdk -DFLUID_PATH=../core ..

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -27,7 +27,7 @@ jobs:
           run: git clone --branch dev https://github.com/flucoma/flucoma-docs.git docs
         
         - name: cmake
-          run: cmake -GNinja -DFLUID_PATH=../core -DDOCS=ON -DFLUID_DOCS_PATH=../docs ..
+          run: cmake -GNinja -DFLUID_PATH=../core -DPD_PATH=../sdk -DDOCS=ON -DFLUID_DOCS_PATH=../docs ..
           working-directory: build
           
         - name: install

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -60,9 +60,6 @@ jobs:
         run: cmake --build . --target install --config Release
         working-directory: build
 
-      - name: remove pdb files
-        run: Remove-Item install -Recurse -Include *.pdb
-
       - name: zip release
         run: Compress-Archive release-packaging/FluidCorpusManipulation FluCoMa-PD-Windows-nightly.zip
 

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,0 +1,131 @@
+name: Nightly Releases
+
+on:
+  push:
+    branches: [ dev, ci/nightlies ]
+
+jobs:
+  # Eventually this https://github.community/t/create-matrix-with-multiple-os-and-env-for-each-one/16895/5
+  macbuild:
+    runs-on: macos-11
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: get pd source
+        run: git clone https://github.com/pure-data/pure-data.git sdk
+        
+      - name: make build directory
+        run: mkdir -p build
+        
+      - name: cmake
+        run: cmake -DSC_PATH=../sdk ..
+        working-directory: build
+        
+      - name: install
+        run: make install -j$(sysctl -n hw.ncpu)
+        working-directory: build
+
+      - name: zip release
+        run: zip -r ../FluCoMa-PD-Mac-nightly.zip FluidCorpusManipulation
+        working-directory: release-packaging
+
+      - uses: actions/upload-artifact@v2                                                                                                                                                 
+        with:                                                                                                                                                                            
+          name: macbuild                                                                                                                                                                 
+          path: FluCoMa-PD-Mac-nightly.zip
+
+  winbuild:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: get pd source
+        run: git clone https://github.com/pure-data/pure-data.git sdk
+        
+      - name: make build directory
+        run: mkdir -p build
+        
+      - name: cmake
+        run: cmake -DSC_PATH="../sdk" ..
+        working-directory: build
+        
+      - name: install
+        run: cmake --build . --target install
+        working-directory: build
+
+      - name: remove pdb files
+        run: Remove-Item install -Recurse -Include *.pdb
+
+      - name: zip release
+        run: Compress-Archive release-packaging/FluidCorpusManipulation FluCoMa-PD-Windows-nightly.zip
+
+      - uses: actions/upload-artifact@v2                                                                                                                                                 
+        with:                                                                                                                                                                            
+          name: winbuild                                                                                                                                                                
+          path: FluCoMa-PD-Windows-nightly.zip
+
+  linuxbuild:
+    runs-on: ubuntu-18.04
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: get pd source
+        run: git clone https://github.com/pure-data/pure-data.git sdk
+        
+      - name: make build directory
+        run: mkdir -p build
+        
+      - name: cmake
+        run: cmake -DSC_PATH=../sdk ..
+        working-directory: build
+        
+      - name: install
+        run: make install -j$(nproc)
+        working-directory: build
+
+      - name: zip release
+        run: zip -r ../FluCoMa-PD-Linux-nightly.zip FluidCorpusManipulation
+        working-directory: release-packaging
+
+      - uses: actions/upload-artifact@v2                                                                                                                                                 
+        with:                                                                                                                                                                            
+          name: linuxbuild                                                                                                                                                                
+          path: FluCoMa-PD-Linux-nightly.zip
+  
+  release:
+    runs-on: ubuntu-latest
+    needs: [macbuild, winbuild, linuxbuild]
+
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: macbuild
+          path: .
+      
+      - uses: actions/download-artifact@v2
+        with:
+          name: winbuild
+          path: .
+
+      - uses: actions/download-artifact@v2
+        with:
+          name: linuxbuild
+          path: .
+      
+      - name: see
+        run: ls -R
+        
+      - name: package and upload
+        uses: svenstaro/upload-release-action@v2
+        with:
+          release_name: FluCoMa Max Nightly Build
+          prerelease: true
+          body: "This is a nightly build of the FluCoMa Max package. As such, be warned there may be bugs or other unexpected behaviour. The build hash is ${{ github.sha }}"
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: FluCoMa-PD-*.zip
+          file_glob: true
+          tag: 1.0.0-nightly
+          overwrite: true

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -126,8 +126,12 @@ jobs:
           name: linuxbuild
           path: .
       
-      - name: see
-        run: ls -R
+      - uses: dev-drprasad/delete-tag-and-release@v0.2.0
+        with:
+          delete_release: true
+          tag_name: 1.0.0-nightly
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         
       - name: package and upload
         uses: svenstaro/upload-release-action@v2

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -41,8 +41,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: get pd source
-        run: git clone https://github.com/pure-data/pure-data.git sdk
+      - name: get pd binaries
+        run : Invoke-WebRequest -Uri https://msp.puredata.info/Software/pd-0.51-4.msw.zip -OutFile sdk.zip
+
+      - name: unzip pd binaries
+        run: Expand-Archive sdk.zip -DestinationPath ./ -Force
+
+      - name: ls
         
       - name: make build directory
         run: mkdir -p build
@@ -72,16 +77,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      # - name: get pd source
-      #   run: git clone https://github.com/pure-data/pure-data.git sdk
-
-      - name: get pd binaries
-        run : Invoke-WebRequest -Uri https://msp.puredata.info/Software/pd-0.51-4.msw.zip -OutFile sdk.zip
-
-      - name: unzip pd binaries
-        run: Expand-Archive sdk.zip -DestinationPath ./ -Force
-
-      - name: ls
+      - name: get pd source
+        run: git clone https://github.com/pure-data/pure-data.git sdk
         
       - name: make build directory
         run: mkdir -p build

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -16,9 +16,12 @@ jobs:
         
       - name: make build directory
         run: mkdir -p build
+
+      - name: clone latest flucoma-core
+        run: git clone --branch dev https://github.com/flucoma/flucoma-sc.git core   
         
       - name: cmake
-        run: cmake -DPD_PATH=../sdk ..
+        run: cmake -DPD_PATH=../sdk -DFLUID_CORE=../core ..
         working-directory: build
         
       - name: install
@@ -51,9 +54,12 @@ jobs:
         
       - name: make build directory
         run: mkdir -p build
+
+      - name: clone latest flucoma-core
+        run: git clone --branch dev https://github.com/flucoma/flucoma-sc.git core   
         
       - name: cmake
-        run: cmake -DPD_PATH="../pd-0.51-4" ..
+        run: cmake -DPD_PATH="../pd-0.51-4" -DFLUID_CORE="../core" ..
         working-directory: build
         
       - name: install
@@ -79,9 +85,12 @@ jobs:
         
       - name: make build directory
         run: mkdir -p build
+
+      - name: clone latest flucoma-core
+        run: git clone --branch dev https://github.com/flucoma/flucoma-sc.git core
         
       - name: cmake
-        run: cmake -DPD_PATH=../sdk ..
+        run: cmake -DPD_PATH=../sdk -DFLUID_CORE=../core ..
         working-directory: build
         
       - name: install

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -21,7 +21,7 @@ jobs:
         run: git clone --branch dev https://github.com/flucoma/flucoma-sc.git core   
         
       - name: cmake
-        run: cmake -DPD_PATH=../sdk -DFLUID_CORE=../core ..
+        run: cmake -DPD_PATH=../sdk -DFLUID_PATH=../core ..
         working-directory: build
         
       - name: install

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -5,11 +5,47 @@ on:
     branches: [ dev, ci/nightlies ]
 
 jobs:
+
+  docs:
+      runs-on: ubuntu-18.04
+      steps:
+        - uses: actions/checkout@v2
+
+        - name: install ninja
+          run: sudo apt update && sudo apt install ninja-build
+
+        - name: install python dependencies
+          run: pip3 install pyyaml docutils jinja2
+          
+        - name: make build directory
+          run: mkdir -p build
+
+        - name: clone latest flucoma-core 
+          run: git clone --branch dev https://github.com/flucoma/flucoma-core.git core
+
+        - name: clone latest flucoma-docs
+          run: git clone --branch dev https://github.com/flucoma/flucoma-docs.git docs
+        
+        - name: cmake
+          run: cmake -GNinja -DFLUID_PATH=../core -DDOCS=ON -DFLUID_DOCS_PATH=../docs ..
+          working-directory: build
+          
+        - name: install
+          run: ninja MAKE_PD_REF
+          working-directory: build
+
+        - uses: actions/upload-artifact@v2
+          with:
+            name: docs
+            path: build/pd_ref
+
   macbuild:
     runs-on: macos-11
-
     steps:
       - uses: actions/checkout@v2
+
+      - name: install ninja
+        run: brew install ninja
 
       - name: get pd source
         run: git clone https://github.com/pure-data/pure-data.git sdk
@@ -21,25 +57,20 @@ jobs:
         run: git clone --branch dev https://github.com/flucoma/flucoma-core.git core   
         
       - name: cmake
-        run: cmake -DPD_PATH=../sdk -DFLUID_PATH=../core ..
+        run: cmake -GNinja -DPD_PATH=../sdk -DFLUID_PATH=../core ..
         working-directory: build
         
       - name: install
-        run: make install -j$(sysctl -n hw.ncpu)
+        run: ninja install
         working-directory: build
-
-      - name: zip release
-        run: zip -r ../FluCoMa-PD-Mac-nightly.zip FluidCorpusManipulation
-        working-directory: release-packaging
 
       - uses: actions/upload-artifact@v2                                                                                                                                                 
         with:                                                                                                                                                                            
           name: macbuild                                                                                                                                                                 
-          path: FluCoMa-PD-Mac-nightly.zip
+          path: release-packaging/FluidCorpusManipulation
 
   winbuild:
     runs-on: windows-latest
-
     steps:
       - uses: actions/checkout@v2
 
@@ -48,9 +79,6 @@ jobs:
 
       - name: unzip pd binaries
         run: Expand-Archive sdk.zip -DestinationPath ./ -Force
-
-      - name: ls
-        run: ls
         
       - name: make build directory
         run: mkdir -p build
@@ -66,19 +94,18 @@ jobs:
         run: cmake --build . --target install --config Release
         working-directory: build
 
-      - name: zip release
-        run: Compress-Archive release-packaging/FluidCorpusManipulation FluCoMa-PD-Windows-nightly.zip
-
       - uses: actions/upload-artifact@v2                                                                                                                                                 
         with:                                                                                                                                                                            
           name: winbuild                                                                                                                                                                
-          path: FluCoMa-PD-Windows-nightly.zip
+          path: "release-packaging/FluidCorpusManipulation"
 
   linuxbuild:
     runs-on: ubuntu-18.04
-
     steps:
       - uses: actions/checkout@v2
+
+      - name: install ninja 
+        run: sudo apt update && sudo apt install ninja-build
 
       - name: get pd source
         run: git clone https://github.com/pure-data/pure-data.git sdk
@@ -90,42 +117,68 @@ jobs:
         run: git clone --branch dev https://github.com/flucoma/flucoma-core.git core
         
       - name: cmake
-        run: cmake -DPD_PATH=../sdk -DFLUID_PATH=../core ..
+        run: cmake -GNinja -DPD_PATH=../sdk -DFLUID_PATH=../core ..
         working-directory: build
         
       - name: install
-        run: make install -j$(nproc)
+        run: ninja install
         working-directory: build
-
-      - name: zip release
-        run: zip -r ../FluCoMa-PD-Linux-nightly.zip FluidCorpusManipulation
-        working-directory: release-packaging
 
       - uses: actions/upload-artifact@v2                                                                                                                                                 
         with:                                                                                                                                                                            
           name: linuxbuild                                                                                                                                                                
-          path: FluCoMa-PD-Linux-nightly.zip
+          path: release-packaging/FluidCorpusManipulation
   
   release:
     runs-on: ubuntu-latest
-    needs: [macbuild, winbuild, linuxbuild]
+    needs: [macbuild, winbuild, linuxbuild, docs]
 
     steps:
       - uses: actions/download-artifact@v2
         with:
-          name: macbuild
-          path: .
-      
-      - uses: actions/download-artifact@v2
-        with:
-          name: winbuild
-          path: .
+          name: docs
+          path: docs
 
+      #### LINUX ####
       - uses: actions/download-artifact@v2
         with:
           name: linuxbuild
-          path: .
+          path: linux
       
+      - name: copy docs to linux
+        run: cp -r docs linux
+
+      - name: compress linux
+        run: zip -r ../FluCoMa-PD-Linux-nightly.zip .
+        working-directory: linux
+
+      #### MAC ####
+      - uses: actions/download-artifact@v2
+        with:
+          name: macbuild
+          path: mac
+
+      - name: copy docs to mac
+        run: cp -r docs mac
+
+      - name: compress mac
+        run: zip -r ../FluCoMa-PD-Mac-nightly.zip .
+        working-directory: mac
+
+      #### WINDOWS ####
+      - uses: actions/download-artifact@v2
+        with:
+          name: winbuild
+          path: win
+
+      - name: copy docs to windows
+        run: cp -r docs win
+
+      - name: compress windows
+        run: zip -r ../FluCoMa-CLI-Windows-nightly.zip .
+        working-directory: win
+      
+      #### UPLOAD RELEASE ####
       - uses: dev-drprasad/delete-tag-and-release@v0.2.0
         with:
           delete_release: true

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -72,14 +72,22 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: get pd source
-        run: git clone https://github.com/pure-data/pure-data.git sdk
+      # - name: get pd source
+      #   run: git clone https://github.com/pure-data/pure-data.git sdk
+
+      - name: get pd binaries
+        run : Invoke-WebRequest -Uri https://msp.puredata.info/Software/pd-0.51-4.msw.zip -OutFile sdk.zip
+
+      - name: unzip pd binaries
+        run: Expand-Archive sdk.zip -DestinationPath ./ -Force
+
+      - name: ls
         
       - name: make build directory
         run: mkdir -p build
         
       - name: cmake
-        run: cmake -DPD_PATH=../sdk ..
+        run: cmake -DPD_PATH=../pd-0.51-4 ..
         working-directory: build
         
       - name: install

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -53,7 +53,7 @@ jobs:
         run: mkdir -p build
         
       - name: cmake
-        run: cmake -DPD_PATH="../sdk" ..
+        run: cmake -DPD_PATH="../pd-0.51-4" ..
         working-directory: build
         
       - name: install
@@ -84,7 +84,7 @@ jobs:
         run: mkdir -p build
         
       - name: cmake
-        run: cmake -DPD_PATH=../pd-0.51-4 ..
+        run: cmake -DPD_PATH=../sdk ..
         working-directory: build
         
       - name: install


### PR DESCRIPTION
This facilitates the automation generation of nightly builds for each push on the dev branch.

You can see the example results here:

https://github.com/jamesb93/flucoma-pd/releases
