### PR TITLE
[CI] Folder structure at output is wrong

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/upload-artifact@v2                                                                                                                                                 
         with:                                                                                                                                                                            
           name: macbuild                                                                                                                                                                 
-          path: release-packaging/FluidCorpusManipulation
+          path: release-packaging
 
   winbuild:
     runs-on: windows-latest
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/upload-artifact@v2                                                                                                                                                 
         with:                                                                                                                                                                            
           name: winbuild                                                                                                                                                                
-          path: "release-packaging/FluidCorpusManipulation"
+          path: "release-packaging"
 
   linuxbuild:
     runs-on: ubuntu-18.04
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/upload-artifact@v2                                                                                                                                                 
         with:                                                                                                                                                                            
           name: linuxbuild                                                                                                                                                                
-          path: release-packaging/FluidCorpusManipulation
+          path: release-packaging
   
   release:
     runs-on: ubuntu-latest
@@ -70,11 +70,11 @@ jobs:
           path: linux
       
       - name: copy docs to linux
-        run: cp -r docs linux
+        run: cp -r docs linux/FluidCorpusManipulation
 
       - name: compress linux
-        run: zip -r ../FluCoMa-PD-Linux-nightly.zip .
-        working-directory: linux
+        run: zip -r ../../FluCoMa-PD-Linux-nightly.zip .
+        working-directory: linux/FluidCorpusManipulation
 
       #### MAC ####
       - uses: actions/download-artifact@v2
@@ -83,11 +83,11 @@ jobs:
           path: mac
 
       - name: copy docs to mac
-        run: cp -r docs mac
+        run: cp -r docs mac/FluidCorpusManipulation
 
       - name: compress mac
-        run: zip -r ../FluCoMa-PD-Mac-nightly.zip .
-        working-directory: mac
+        run: zip -r ../../FluCoMa-PD-Mac-nightly.zip .
+        working-directory: mac/FluidCorpusManipulation
 
       #### WINDOWS ####
       - uses: actions/download-artifact@v2
@@ -96,11 +96,11 @@ jobs:
           path: win
 
       - name: copy docs to windows
-        run: cp -r docs win
+        run: cp -r docs win/FluidCorpusManipulation
 
       - name: compress windows
-        run: zip -r ../FluCoMa-PD-Windows-nightly.zip .
-        working-directory: win
+        run: zip -r ../../FluCoMa-PD-Windows-nightly.zip .
+        working-directory: win/FluidCorpusManipulation
       
       #### UPLOAD RELEASE ####
       - uses: dev-drprasad/delete-tag-and-release@v0.2.0

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -9,12 +9,8 @@ jobs:
     runs-on: macos-11
     steps:
       - uses: actions/checkout@v2
-
-      - name: setup environment
-        uses: flucoma/actions/env@v2
-
-      - name: build docs
-        uses: flucoma/actions/pddocs@v2
+      - uses: flucoma/actions/env@v2
+      - uses: flucoma/actions/pddocs@v2
 
       - uses: actions/upload-artifact@v2
         with:
@@ -25,12 +21,8 @@ jobs:
     runs-on: macos-11
     steps:
       - uses: actions/checkout@v2
-
-      - name: setup environment
-        uses: flucoma/actions/env@v2 
-        
-      - name: build toolkit
-        uses: flucoma/actions/pd@v2
+      - uses: flucoma/actions/env@v2 
+      - uses: flucoma/actions/pd@v2
 
       - uses: actions/upload-artifact@v2                                                                                                                                                 
         with:                                                                                                                                                                            
@@ -41,12 +33,8 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
-
-      - name: setup environment
-        uses: flucoma/actions/env@v2 
-        
-      - name: build toolkit
-        uses: flucoma/actions/pd@v2
+      - uses: flucoma/actions/env@v2         
+      - uses: flucoma/actions/pd@v2
 
       - uses: actions/upload-artifact@v2                                                                                                                                                 
         with:                                                                                                                                                                            
@@ -57,12 +45,8 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
-
-      - name: setup environment
-        uses: flucoma/actions/env@v2 
-        
-      - name: build toolkit
-        uses: flucoma/actions/pd@v2
+      - uses: flucoma/actions/env@v2 
+      - uses: flucoma/actions/pd@v2
 
       - uses: actions/upload-artifact@v2                                                                                                                                                 
         with:                                                                                                                                                                            

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -73,8 +73,8 @@ jobs:
         run: cp -r docs linux/FluidCorpusManipulation
 
       - name: compress linux
-        run: zip -r ../../FluCoMa-PD-Linux-nightly.zip .
-        working-directory: linux/FluidCorpusManipulation
+        run: zip -r ../FluCoMa-PD-Linux-nightly.zip .
+        working-directory: linux
 
       #### MAC ####
       - uses: actions/download-artifact@v2
@@ -86,8 +86,8 @@ jobs:
         run: cp -r docs mac/FluidCorpusManipulation
 
       - name: compress mac
-        run: zip -r ../../FluCoMa-PD-Mac-nightly.zip .
-        working-directory: mac/FluidCorpusManipulation
+        run: zip -r ../FluCoMa-PD-Mac-nightly.zip .
+        working-directory: mac
 
       #### WINDOWS ####
       - uses: actions/download-artifact@v2
@@ -99,8 +99,8 @@ jobs:
         run: cp -r docs win/FluidCorpusManipulation
 
       - name: compress windows
-        run: zip -r ../../FluCoMa-PD-Windows-nightly.zip .
-        working-directory: win/FluidCorpusManipulation
+        run: zip -r ../FluCoMa-PD-Windows-nightly.zip .
+        working-directory: win
       
       #### UPLOAD RELEASE ####
       - uses: dev-drprasad/delete-tag-and-release@v0.2.0


### PR DESCRIPTION
Currently the unzipped PD externals will expand into the bare package folder. It should unfold into a folder called FluidCorpusManipulation, just like the other CCEs.﻿
