### PR TITLE
Fix/issue 17

### DIFF
--- a/include/PDBufferAdaptor.hpp
+++ b/include/PDBufferAdaptor.hpp
@@ -69,7 +69,7 @@ public:
     {
       r.set(Result::Status::kError);
       r.addMessage("Not enough arrays to operate on ", mName->s_name,
-                   ". Found ", channels, " array(s) but need ", nChans, ".");
+                   ". Found ", nChans, " array(s) but need ", channels, ".");
     }
 
     for (index i = 0; i < nChans; ++i)


### PR DESCRIPTION
This corrects the order of variables the error message from `PDBufferAdaptor` when the channel count is insufficient, so now the error should make sense when it happens. 

closes #17 (although the substance of that issue wasn't a bug but a misnamed parameter) 