### PR TITLE
[Enhance] Retrieve toy DataSets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ pd_objects/
 media
 docs
 release-packaging/
+data

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,8 @@ FetchContent_GetProperties(flucoma-core)
 if(NOT flucoma-core_POPULATED)
   FetchContent_Populate(flucoma-core)
   add_subdirectory(${flucoma-core_SOURCE_DIR} ${flucoma-core_BINARY_DIR})
+  file(GLOB FLUCOMA_CORE_RESOURCES ${flucoma-core_SOURCE_DIR}/Resources/Data/*.*)
+  file(COPY ${FLUCOMA_CORE_RESOURCES} DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}/data)
   include(flucoma_version)
   include(flucoma-buildtools)
   include(flucoma-buildtype)
@@ -152,8 +154,8 @@ install(DIRECTORY examples
         DESTINATION ${PD_PACKAGE_ROOT})
 install(DIRECTORY "${flucoma-core_SOURCE_DIR}/Resources/AudioFiles/" 
         DESTINATION "${PD_PACKAGE_ROOT}/media")
-install(DIRECTORY "${flucoma-core_SOURCE_DIR}/Resources/DataSets/"
-        DESTINATION "${PD_PACKAGE_ROOT}/datasets")
+install(DIRECTORY "${flucoma-core_SOURCE_DIR}/Resources/Data/"
+        DESTINATION "${PD_PACKAGE_ROOT}/data")
 install(FILES icon.png QuickStart.md 
         DESTINATION ${PD_PACKAGE_ROOT})
 install(FILES ${flucoma-core_SOURCE_DIR}/distribution.lic 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,7 +153,7 @@ install(DIRECTORY examples
 install(DIRECTORY "${flucoma-core_SOURCE_DIR}/Resources/AudioFiles/" 
         DESTINATION "${PD_PACKAGE_ROOT}/media")
 install(DIRECTORY "${flucoma-core_SOURCE_DIR}/Resources/DataSets/"
-        DESTINATION "${PD_PACKAGE_ROOT}/")
+        DESTINATION "${PD_PACKAGE_ROOT}/datasets")
 install(FILES icon.png QuickStart.md 
         DESTINATION ${PD_PACKAGE_ROOT})
 install(FILES ${flucoma-core_SOURCE_DIR}/distribution.lic 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,8 +150,10 @@ install(DIRECTORY abstractions/
         FILES_MATCHING PATTERN "*.pd")
 install(DIRECTORY examples 
         DESTINATION ${PD_PACKAGE_ROOT})
-install(DIRECTORY "${flucoma-core_SOURCE_DIR}/AudioFiles/" 
+install(DIRECTORY "${flucoma-core_SOURCE_DIR}/Resources/AudioFiles/" 
         DESTINATION "${PD_PACKAGE_ROOT}/media")
+install(DIRECTORY "${flucoma-core_SOURCE_DIR}/Resources/DataSets/"
+        DESTINATION "${PD_PACKAGE_ROOT}/")
 install(FILES icon.png QuickStart.md 
         DESTINATION ${PD_PACKAGE_ROOT})
 install(FILES ${flucoma-core_SOURCE_DIR}/distribution.lic 


### PR DESCRIPTION
Adjusts paths in the CMake configuration for where AudioFiles and the new DataSets (see flucoma/flucoma-core#88) are retrieved from.﻿

It seems that I cannot nest the datasets in an arbitrarily deep folder structure and so the datasets need to be at the top level of the package folder for them to be picked up by calling `read dataset.json`, for example.

If there is a better solution (to which I defer to @tremblap) let's do that because this will clutter the package but is nonetheless necessary.