### PR TITLE
sort the naming error in the helpfiles

### DIFF
--- a/help/fluid.bufmelbands-help.pd
+++ b/help/fluid.bufmelbands-help.pd
@@ -68,7 +68,7 @@ melbands., f 100;
 #X array bufmelbands_drums 453932 float 0;
 #X coords 0 0.5 453931 -0.5 887 53 1 0 0;
 #X restore 31 299 graph;
-#X obj 674 194 note_on_assumed_sampling_rates_of_arrays;
+#X obj 674 194 note_on_sampling_rates
 #X obj 398 128 fluid.bufmelbands 10 -source bufmelbands_drums -features
 bufmelbands_feats, f 75;
 #X msg 33 177 read -resize media/Nicol-LoopE-M.wav bufmelbands_drums

--- a/help/fluid.bufmfcc-help.pd
+++ b/help/fluid.bufmfcc-help.pd
@@ -80,7 +80,7 @@ xticks 0 0 0 \; bufmfcc_feats-9 xticks 0 0 0 \; bufmfcc_feats-10 xticks
 #X restore 31 299 graph;
 #X obj 379 117 fluid\.bufmfcc 13 -source bufmfcc_drums -features bufmfcc_feats
 , f 63;
-#X obj 675 186 note_on_assumed_sampling_rates_of_arrays;
+#X obj 675 186 note_on_sampling_rates
 #N canvas 0 22 450 278 (subpatch) 0;
 #X array bufmfcc_feats-1 915 float 0;
 #X coords 0 200 914 -200 887 30 1 0 0;

--- a/help/fluid.bufpitch-help.pd
+++ b/help/fluid.bufpitch-help.pd
@@ -58,7 +58,7 @@ xticks 0 0 0;
 #X obj 195 810 tabread bufpitch-feats-1;
 #X obj 37 398 fluid\.bufpitch -source pitch-source -features bufpitch-feats
 , f 61;
-#X obj 306 437 note_on_assumed_sampling_rates_of_arrays;
+#X obj 306 437 note_on_sampling_rates
 #X text 35 495 2) observe the pitch estimate (top) and the confidence
 in this value (bottom), f 82;
 #X floatatom 37 750 5 0 0 0 - - -;

--- a/help/fluid.bufspectralshape-help.pd
+++ b/help/fluid.bufspectralshape-help.pd
@@ -144,7 +144,7 @@ bufshape_feats, f 40;
 #X text 144 348 centroid(Hz):;
 #X text 145 418 spread(Hz):;
 #X text 144 628 rolloff(Hz):;
-#X obj 671 217 note_on_assumed_sampling_rates_of_arrays;
+#X obj 671 217 note_on_sampling_rates
 #X obj 410 170 fluid\.bufspectralshape -source bufshape_drums -features
 bufshape_feats, f 71;
 #N canvas 0 23 450 300 (subpatch) 0;


### PR DESCRIPTION
this sorts the renaming of the explainer in the old non-refurbished help files