### PR TITLE
[enhance] Add install step for local documentation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,6 +187,8 @@ install(FILES ${flucoma-core_SOURCE_DIR}/distribution.lic
         RENAME LICENSE.md)
 install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/FluidCorpusManipulationOverview.pd 
         DESTINATION ${PD_PACKAGE_ROOT})
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/local_docs/"
+        DESTINATION "${PD_PACKAGE_ROOT}/docs")
 if(DOCS)
   install(DIRECTORY "${PD_DOC_OUT}/" 
           DESTINATION "${PD_PACKAGE_ROOT}/docs" 

--- a/local_docs/fluid.bufinfo.html
+++ b/local_docs/fluid.bufinfo.html
@@ -1,0 +1,77 @@
+<!--
+Part of the Fluid Corpus Manipulation Project (http://www.flucoma.org/)
+Copyright 2017-2019 University of Huddersfield.
+Licensed under the BSD-3 License.
+See license.md file in the project root for full license information.
+This project has received funding from the European Research Council (ERC)
+under the European Union’s Horizon 2020 research and innovation programme
+(grant agreement No 725899).
+-->
+<!DOCTYPE html>
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>fluid.bufinfo Reference</title>
+<style>
+	* {
+		font-family:system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+		--blue: rgb(80,164,252);
+		--dark-blue: #204265;
+	}
+
+	body {
+		padding: 1em;
+	}
+
+	h1 {
+		text-decoration: underline;
+		background-color: var(--blue);
+		color: white;
+		padding: 0.25em;
+		margin: 0;
+	}
+	h2 {
+		border-bottom: 0.5px solid rgba(128, 128, 128, 0.513);
+	}
+
+	a {
+		color: var(--blue);
+	}
+
+	a:hover {
+		background-color: var(--blue);
+		color: white;
+	}
+	
+	.type, .defaultval { 
+		font-weight: normal; 
+  	}
+</style> 
+</head>
+<body>
+  	<h1 class="ref_title">fluid.bufinfo</h1>
+  	<div class="digest">Query fluid.multiarray</div>
+  	<section class="object_description">
+		<h2>Description</h2> 
+	<p>An abstraction for querying various attributes of a fluid.multiarray</p>
+  	</section> 
+  		<section class="object_discussion"> 
+    	<h2>Discussion</h2> 
+    	<p>This object is designed for testing the validity, the size in frames and the number of channels of a fluid.multiarray, either when created via the clone object, or programmatically with automatically generated 'buffers'.
+</p>
+    	<p>fluid.bufinfo is part of the Fluid Decomposition Toolkit of the FluCoMa project. For more explanations, learning material, and discussions on its musicianly uses, visit <a href="http://www.flucoma.org/">flucoma.org</a>.</p>
+  	</section>
+  	<section class="argument_section">
+    	<h2>Arguments</h2>
+ 	 </section> 
+  	<section class="attribute_section">
+    <h2>Attributes</h2>
+  	</section> 
+  	<section class="method_section"> 
+    <h2>Messages</h2>
+  </section> 
+  <section class="seealso"> 
+    <h2>See Also</h2> 
+  </section> 
+</body>
+</html>

--- a/local_docs/fluid.concataudiofiles.html
+++ b/local_docs/fluid.concataudiofiles.html
@@ -1,0 +1,94 @@
+<!--
+Part of the Fluid Corpus Manipulation Project (http://www.flucoma.org/)
+Copyright 2017-2019 University of Huddersfield.
+Licensed under the BSD-3 License.
+See license.md file in the project root for full license information.
+This project has received funding from the European Research Council (ERC)
+under the European Union’s Horizon 2020 research and innovation programme
+(grant agreement No 725899).
+-->
+<!DOCTYPE html>
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>fluid.concataudiofiles Reference</title>
+<style>
+	* {
+		font-family:system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+		--blue: rgb(80,164,252);
+		--dark-blue: #204265;
+	}
+
+	body {
+		padding: 1em;
+	}
+
+	h1 {
+		text-decoration: underline;
+		background-color: var(--blue);
+		color: white;
+		padding: 0.25em;
+		margin: 0;
+	}
+	h2 {
+		border-bottom: 0.5px solid rgba(128, 128, 128, 0.513);
+	}
+
+	a {
+		color: var(--blue);
+	}
+
+	a:hover {
+		background-color: var(--blue);
+		color: white;
+	}
+	
+	.type, .defaultval { 
+		font-weight: normal; 
+  	}
+</style> 
+</head>
+<body>
+  	<h1 class="ref_title">fluid.concataudiofiles</h1>
+  	<div class="digest">A utility to concatenate audio files</div>
+  	<section class="object_description">
+		<h2>Description</h2> 
+	<p>Given a list of valid audio file paths, concatenates them into a single array.</p>
+  	</section> 
+  		<section class="object_discussion"> 
+    	<h2>Discussion</h2> 
+    	<p>This object takes a list of paths to audio files, loads them one after the other into a <a href='fluid.multiarray.html'>fluid.multiarray</a>, and fills a text with the filenames, start and end frames, sampling rate and channel count.
+</p>
+    	<p>fluid.concataudiofiles is part of the Fluid Decomposition Toolkit of the FluCoMa project. For more explanations, learning material, and discussions on its musicianly uses, visit <a href="http://www.flucoma.org/">flucoma.org</a>.</p>
+  	</section>
+  	<section class="argument_section">
+    	<h2>Arguments</h2>
+      	<h3 class="argument_name">multiarray<span class="type"> [symbol]</span></h3> 
+      	<div class="optional">Optional</div> 
+    	<div class="description">Given a list of valid audio file paths, concatenates them into a single array.</div>
+      	<h3 class="argument_name">text<span class="type"> [symbol]</span></h3> 
+      	<div class="optional">Optional</div> 
+    	<div class="description">A destination text object to store metadata about the concatenated files</div>
+ 	 </section> 
+  	<section class="attribute_section">
+    <h2>Attributes</h2>
+  	</section> 
+  	<section class="method_section"> 
+    <h2>Messages</h2>
+	<div class='method_group'>
+		<h3 class='method_name' name='list'>list</h3>
+		<span class='arglist'>Arguments: </span>
+		<div class='description'>
+		<p>Trigger concatenation</p>
+		</div>
+
+		<h5>Argument details:</h5>
+		<ul>
+		</ul>
+	</div>
+  </section> 
+  <section class="seealso"> 
+    <h2>See Also</h2> 
+  </section> 
+</body>
+</html>

--- a/local_docs/fluid.ds2text.html
+++ b/local_docs/fluid.ds2text.html
@@ -1,0 +1,94 @@
+<!--
+Part of the Fluid Corpus Manipulation Project (http://www.flucoma.org/)
+Copyright 2017-2019 University of Huddersfield.
+Licensed under the BSD-3 License.
+See license.md file in the project root for full license information.
+This project has received funding from the European Research Council (ERC)
+under the European Union’s Horizon 2020 research and innovation programme
+(grant agreement No 725899).
+-->
+<!DOCTYPE html>
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>fluid.ds2text Reference</title>
+<style>
+	* {
+		font-family:system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+		--blue: rgb(80,164,252);
+		--dark-blue: #204265;
+	}
+
+	body {
+		padding: 1em;
+	}
+
+	h1 {
+		text-decoration: underline;
+		background-color: var(--blue);
+		color: white;
+		padding: 0.25em;
+		margin: 0;
+	}
+	h2 {
+		border-bottom: 0.5px solid rgba(128, 128, 128, 0.513);
+	}
+
+	a {
+		color: var(--blue);
+	}
+
+	a:hover {
+		background-color: var(--blue);
+		color: white;
+	}
+	
+	.type, .defaultval { 
+		font-weight: normal; 
+  	}
+</style> 
+</head>
+<body>
+  	<h1 class="ref_title">fluid.ds2text</h1>
+  	<div class="digest">Convert FluCoMa DataSet into text</div>
+  	<section class="object_description">
+		<h2>Description</h2> 
+	<p>A utility object to convert a fluid.dataset into text.</p>
+  	</section> 
+  		<section class="object_discussion"> 
+    	<h2>Discussion</h2> 
+    	<p>This is an object for conveniently converting a <a href='fluid.dataset.html'>fluid.dataset</a> into text.
+</p>
+    	<p>fluid.ds2text is part of the Fluid Decomposition Toolkit of the FluCoMa project. For more explanations, learning material, and discussions on its musicianly uses, visit <a href="http://www.flucoma.org/">flucoma.org</a>.</p>
+  	</section>
+  	<section class="argument_section">
+    	<h2>Arguments</h2>
+      	<h3 class="argument_name">dataset<span class="type"> [symbol]</span></h3> 
+      	<div class="optional">Optional</div> 
+    	<div class="description">A source dataset</div>
+      	<h3 class="argument_name">text<span class="type"> [symbol]</span></h3> 
+      	<div class="optional">Optional</div> 
+    	<div class="description">A destination text object</div>
+ 	 </section> 
+  	<section class="attribute_section">
+    <h2>Attributes</h2>
+  	</section> 
+  	<section class="method_section"> 
+    <h2>Messages</h2>
+	<div class='method_group'>
+		<h3 class='method_name' name='bang'>bang</h3>
+		<span class='arglist'>Arguments: </span>
+		<div class='description'>
+		<p>Trigger processing</p>
+		</div>
+
+		<h5>Argument details:</h5>
+		<ul>
+		</ul>
+	</div>
+  </section> 
+  <section class="seealso"> 
+    <h2>See Also</h2> 
+  </section> 
+</body>
+</html>

--- a/local_docs/fluid.ls2text.html
+++ b/local_docs/fluid.ls2text.html
@@ -1,0 +1,94 @@
+<!--
+Part of the Fluid Corpus Manipulation Project (http://www.flucoma.org/)
+Copyright 2017-2019 University of Huddersfield.
+Licensed under the BSD-3 License.
+See license.md file in the project root for full license information.
+This project has received funding from the European Research Council (ERC)
+under the European Union’s Horizon 2020 research and innovation programme
+(grant agreement No 725899).
+-->
+<!DOCTYPE html>
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>fluid.ls2text Reference</title>
+<style>
+	* {
+		font-family:system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+		--blue: rgb(80,164,252);
+		--dark-blue: #204265;
+	}
+
+	body {
+		padding: 1em;
+	}
+
+	h1 {
+		text-decoration: underline;
+		background-color: var(--blue);
+		color: white;
+		padding: 0.25em;
+		margin: 0;
+	}
+	h2 {
+		border-bottom: 0.5px solid rgba(128, 128, 128, 0.513);
+	}
+
+	a {
+		color: var(--blue);
+	}
+
+	a:hover {
+		background-color: var(--blue);
+		color: white;
+	}
+	
+	.type, .defaultval { 
+		font-weight: normal; 
+  	}
+</style> 
+</head>
+<body>
+  	<h1 class="ref_title">fluid.ls2text</h1>
+  	<div class="digest">Convert FluCoMa LabelSet into text</div>
+  	<section class="object_description">
+		<h2>Description</h2> 
+	<p>A utility object to convert a fluid.labelset into text.</p>
+  	</section> 
+  		<section class="object_discussion"> 
+    	<h2>Discussion</h2> 
+    	<p>This is an object for conveniently converting a <a href='fluid.labelset.html'>fluid.labelset</a> into text.
+</p>
+    	<p>fluid.ls2text is part of the Fluid Decomposition Toolkit of the FluCoMa project. For more explanations, learning material, and discussions on its musicianly uses, visit <a href="http://www.flucoma.org/">flucoma.org</a>.</p>
+  	</section>
+  	<section class="argument_section">
+    	<h2>Arguments</h2>
+      	<h3 class="argument_name">labelset<span class="type"> [symbol]</span></h3> 
+      	<div class="optional">Optional</div> 
+    	<div class="description">A source labelset</div>
+      	<h3 class="argument_name">text<span class="type"> [symbol]</span></h3> 
+      	<div class="optional">Optional</div> 
+    	<div class="description">A destination text object</div>
+ 	 </section> 
+  	<section class="attribute_section">
+    <h2>Attributes</h2>
+  	</section> 
+  	<section class="method_section"> 
+    <h2>Messages</h2>
+	<div class='method_group'>
+		<h3 class='method_name' name='bang'>bang</h3>
+		<span class='arglist'>Arguments: </span>
+		<div class='description'>
+		<p>Trigger processing</p>
+		</div>
+
+		<h5>Argument details:</h5>
+		<ul>
+		</ul>
+	</div>
+  </section> 
+  <section class="seealso"> 
+    <h2>See Also</h2> 
+  </section> 
+</body>
+</html>

--- a/local_docs/fluid.multiarray.html
+++ b/local_docs/fluid.multiarray.html
@@ -1,0 +1,86 @@
+<!--
+Part of the Fluid Corpus Manipulation Project (http://www.flucoma.org/)
+Copyright 2017-2019 University of Huddersfield.
+Licensed under the BSD-3 License.
+See license.md file in the project root for full license information.
+This project has received funding from the European Research Council (ERC)
+under the European Union’s Horizon 2020 research and innovation programme
+(grant agreement No 725899).
+-->
+<!DOCTYPE html>
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>fluid.multiarray Reference</title>
+<style>
+	* {
+		font-family:system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+		--blue: rgb(80,164,252);
+		--dark-blue: #204265;
+	}
+
+	body {
+		padding: 1em;
+	}
+
+	h1 {
+		text-decoration: underline;
+		background-color: var(--blue);
+		color: white;
+		padding: 0.25em;
+		margin: 0;
+	}
+	h2 {
+		border-bottom: 0.5px solid rgba(128, 128, 128, 0.513);
+	}
+
+	a {
+		color: var(--blue);
+	}
+
+	a:hover {
+		background-color: var(--blue);
+		color: white;
+	}
+	
+	.type, .defaultval { 
+		font-weight: normal; 
+  	}
+</style> 
+</head>
+<body>
+  	<h1 class="ref_title">fluid.multiarray</h1>
+  	<div class="digest">Multichannel arrays</div>
+  	<section class="object_description">
+		<h2>Description</h2> 
+	<p>An abstraction that assists in the management and creation of multichannel arrays.</p>
+  	</section> 
+  		<section class="object_discussion"> 
+    	<h2>Discussion</h2> 
+    	<p>This abstraction allows the creation of multichannel arrays. Note that it requires invoking with the clone object to work.
+</p>
+    	<p>fluid.multiarray is part of the Fluid Decomposition Toolkit of the FluCoMa project. For more explanations, learning material, and discussions on its musicianly uses, visit <a href="http://www.flucoma.org/">flucoma.org</a>.</p>
+  	</section>
+  	<section class="argument_section">
+    	<h2>Arguments</h2>
+      	<h3 class="argument_name">channels<span class="type"> [int]</span></h3> 
+      	<div class="optional">Optional</div> 
+    	<div class="description">The number of channels for the multiarray</div>
+      	<h3 class="argument_name">name<span class="type"> [symbol]</span></h3> 
+      	<div class="optional">Optional</div> 
+    	<div class="description">The name of the multiarray</div>
+      	<h3 class="argument_name">size<span class="type"> [int]</span></h3> 
+      	<div class="optional">Optional</div> 
+    	<div class="description">The number of elements that the array should store</div>
+ 	 </section> 
+  	<section class="attribute_section">
+    <h2>Attributes</h2>
+  	</section> 
+  	<section class="method_section"> 
+    <h2>Messages</h2>
+  </section> 
+  <section class="seealso"> 
+    <h2>See Also</h2> 
+  </section> 
+</body>
+</html>

--- a/local_docs/fluid.plotter.html
+++ b/local_docs/fluid.plotter.html
@@ -1,0 +1,205 @@
+<!--
+Part of the Fluid Corpus Manipulation Project (http://www.flucoma.org/)
+Copyright 2017-2019 University of Huddersfield.
+Licensed under the BSD-3 License.
+See license.md file in the project root for full license information.
+This project has received funding from the European Research Council (ERC)
+under the European Union’s Horizon 2020 research and innovation programme
+(grant agreement No 725899).
+-->
+<!DOCTYPE html>
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>fluid.plotter Reference</title>
+<style>
+	* {
+		font-family:system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+		--blue: rgb(80,164,252);
+		--dark-blue: #204265;
+	}
+
+	body {
+		padding: 1em;
+	}
+
+	h1 {
+		text-decoration: underline;
+		background-color: var(--blue);
+		color: white;
+		padding: 0.25em;
+		margin: 0;
+	}
+	h2 {
+		border-bottom: 0.5px solid rgba(128, 128, 128, 0.513);
+	}
+
+	a {
+		color: var(--blue);
+	}
+
+	a:hover {
+		background-color: var(--blue);
+		color: white;
+	}
+	
+	.type, .defaultval { 
+		font-weight: normal; 
+  	}
+</style> 
+</head>
+<body>
+  	<h1 class="ref_title">fluid.plotter</h1>
+  	<div class="digest">Plot data in a two-dimensional graph.</div>
+  	<section class="object_description">
+		<h2>Description</h2> 
+	<p>A GUI object that plots data in a two-dimensional graph.</p>
+  	</section> 
+  		<section class="object_discussion"> 
+    	<h2>Discussion</h2> 
+    	<p>The fluid.plotter object can be used as a versatile solution for plotting points in a two-dimensional graph.
+
+It is designed to easily accept the contents of a fluid.dataset via a dictionary as coordinates within the graph as well as the contents of a fluid.labelset~ via a dictionary as colours for points.
+
+There is also an 'advanced' interface that allows the user to specify the coordinates and colours of the points in a more flexible and bespoke manner. See the help file for more information on this.
+</p>
+    	<p>fluid.plotter is part of the Fluid Decomposition Toolkit of the FluCoMa project. For more explanations, learning material, and discussions on its musicianly uses, visit <a href="http://www.flucoma.org/">flucoma.org</a>.</p>
+  	</section>
+  	<section class="argument_section">
+    	<h2>Arguments</h2>
+ 	 </section> 
+  	<section class="attribute_section">
+    <h2>Attributes</h2>
+    <div class="attribute_group">
+    	<h3 class="attribute_name">axis
+        <span class="type"> [int]</span>
+        <span class="defaultval"> (default: 0)</span>
+      	</h3>
+      	<div class="description">In what direction to copy data from the source. <m>0</m> copies frame by frame, <m>1</m> copies channel-by-channel.</div>       
+		</div>
+    <div class="attribute_group">
+    	<h3 class="attribute_name">source
+        <span class="type"> [symbol]</span>
+        <span class="defaultval"> (default: )</span>
+      	</h3>
+      	<div class="description">Sets the source buffer~ to copy data from.</div>       
+		</div>
+    <div class="attribute_group">
+    	<h3 class="attribute_name">startchan
+        <span class="type"> [int]</span>
+        <span class="defaultval"> (default: 0)</span>
+      	</h3>
+      	<div class="description">For multichannel input buffers, which channel to begin copying from. The default is 0.</div>       
+		</div>
+  	</section> 
+  	<section class="method_section"> 
+    <h2>Messages</h2>
+	<div class='method_group'>
+		<h3 class='method_name' name='xrange'>xrange</h3>
+		<span class='arglist'>Arguments: </span>
+		<span class='arg'>min (number)</span>
+		<span class='arg'>max (number)</span>
+		<div class='description'>
+		<p>Set the x-axis range.</p>
+		</div>
+
+		<h5>Argument details:</h5>
+		<ul>
+			<li>min: <p>The minimum value for the x-axis</p></li>
+			<li>max: <p>The maximum value for the x-axis</p></li>
+		</ul>
+	</div>
+	<div class='method_group'>
+		<h3 class='method_name' name='yrange'>yrange</h3>
+		<span class='arglist'>Arguments: </span>
+		<span class='arg'>min (number)</span>
+		<span class='arg'>max (number)</span>
+		<div class='description'>
+		<p>Set the y-axis range.</p>
+		</div>
+
+		<h5>Argument details:</h5>
+		<ul>
+			<li>min: <p>The minimum value for the y-axis</p></li>
+			<li>max: <p>The maximum value for the y-axis</p></li>
+		</ul>
+	</div>
+	<div class='method_group'>
+		<h3 class='method_name' name='range'>range</h3>
+		<span class='arglist'>Arguments: </span>
+		<span class='arg'>min (number)</span>
+		<span class='arg'>max (number)</span>
+		<div class='description'>
+		<p>Set the x- and y-axis ranges.</p>
+		</div>
+
+		<h5>Argument details:</h5>
+		<ul>
+			<li>min: <p>The minimum value for the x-axis and y-axis</p></li>
+			<li>max: <p>The maximum value for the x-axis and y-axis</p></li>
+		</ul>
+	</div>
+	<div class='method_group'>
+		<h3 class='method_name' name='highlight'>highlight</h3>
+		<span class='arglist'>Arguments: </span>
+		<span class='arg'>identifiers (list)</span>
+		<div class='description'>
+		<p>Emphasises the given identifier's points in the plot</p>
+		</div>
+
+		<h5>Argument details:</h5>
+		<ul>
+			<li>identifiers: <p>Any number of identifiers</p></li>
+		</ul>
+	</div>
+	<div class='method_group'>
+		<h3 class='method_name' name='clear'>clear</h3>
+		<span class='arglist'>Arguments: </span>
+		<div class='description'>
+		<p>Clears the graph and all associated data and settings.</p>
+		</div>
+
+		<h5>Argument details:</h5>
+		<ul>
+		</ul>
+	</div>
+	<div class='method_group'>
+		<h3 class='method_name' name='setlabels'>setlabels</h3>
+		<span class='arglist'>Arguments: </span>
+		<span class='arg'>text (symbol)</span>
+		<div class='description'>
+		<p>Set the labels for each point according to their labels in a fluid.labelset.</p>
+		</div>
+
+		<h5>Argument details:</h5>
+		<ul>
+			<li>text: <p>The name of a text object containing data from a fluid.dataset. This message must enter the left inlet.</p></li>
+		</ul>
+	</div>
+	<div class='method_group'>
+		<h3 class='method_name' name='setpoints'>setpoints</h3>
+		<span class='arglist'>Arguments: </span>
+		<span class='arg'>text (symbol)</span>
+		<div class='description'>
+		<p>Set the position for points by their data in a fluid.dataset.</p>
+		</div>
+
+		<h5>Argument details:</h5>
+		<ul>
+			<li>text: <p>The name of a text object containing labels from a fluid.labelset. This message must enter the right inlet.</p></li>
+		</ul>
+	</div>
+  </section> 
+  <section class="seealso"> 
+    <h2>See Also</h2> 
+    <h3 class="seealso_name">
+		<a href='fluid.ds2text.html'>
+		fluid.ds2text
+		</a></h3>    
+    <h3 class="seealso_name">
+		<a href='fluid.ls2text.html'>
+		fluid.ls2text
+		</a></h3>    
+  </section> 
+</body>
+</html>

--- a/local_docs/fluid.s2f.html
+++ b/local_docs/fluid.s2f.html
@@ -1,0 +1,88 @@
+<!--
+Part of the Fluid Corpus Manipulation Project (http://www.flucoma.org/)
+Copyright 2017-2019 University of Huddersfield.
+Licensed under the BSD-3 License.
+See license.md file in the project root for full license information.
+This project has received funding from the European Research Council (ERC)
+under the European Union’s Horizon 2020 research and innovation programme
+(grant agreement No 725899).
+-->
+<!DOCTYPE html>
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>fluid.s2f Reference</title>
+<style>
+	* {
+		font-family:system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+		--blue: rgb(80,164,252);
+		--dark-blue: #204265;
+	}
+
+	body {
+		padding: 1em;
+	}
+
+	h1 {
+		text-decoration: underline;
+		background-color: var(--blue);
+		color: white;
+		padding: 0.25em;
+		margin: 0;
+	}
+	h2 {
+		border-bottom: 0.5px solid rgba(128, 128, 128, 0.513);
+	}
+
+	a {
+		color: var(--blue);
+	}
+
+	a:hover {
+		background-color: var(--blue);
+		color: white;
+	}
+	
+	.type, .defaultval { 
+		font-weight: normal; 
+  	}
+</style> 
+</head>
+<body>
+  	<h1 class="ref_title">fluid.s2f</h1>
+  	<div class="digest">Convert a symbol into a float</div>
+  	<section class="object_description">
+		<h2>Description</h2> 
+	<p>Convert a floating point value expressed as a symbol ('string') and output it as a float.</p>
+  	</section> 
+  		<section class="object_discussion"> 
+    	<h2>Discussion</h2> 
+    	<p>Note that the symbol needs to be enclosed in double quotes for s2f to work.
+</p>
+    	<p>fluid.s2f is part of the Fluid Decomposition Toolkit of the FluCoMa project. For more explanations, learning material, and discussions on its musicianly uses, visit <a href="http://www.flucoma.org/">flucoma.org</a>.</p>
+  	</section>
+  	<section class="argument_section">
+    	<h2>Arguments</h2>
+ 	 </section> 
+  	<section class="attribute_section">
+    <h2>Attributes</h2>
+  	</section> 
+  	<section class="method_section"> 
+    <h2>Messages</h2>
+	<div class='method_group'>
+		<h3 class='method_name' name='xrange'>xrange</h3>
+		<span class='arglist'>Arguments: </span>
+		<div class='description'>
+		<p>Convert the symbol into a float</p>
+		</div>
+
+		<h5>Argument details:</h5>
+		<ul>
+		</ul>
+	</div>
+  </section> 
+  <section class="seealso"> 
+    <h2>See Also</h2> 
+  </section> 
+</body>
+</html>

--- a/local_docs/fluid.waveform.html
+++ b/local_docs/fluid.waveform.html
@@ -1,0 +1,76 @@
+<!--
+Part of the Fluid Corpus Manipulation Project (http://www.flucoma.org/)
+Copyright 2017-2019 University of Huddersfield.
+Licensed under the BSD-3 License.
+See license.md file in the project root for full license information.
+This project has received funding from the European Research Council (ERC)
+under the European Union’s Horizon 2020 research and innovation programme
+(grant agreement No 725899).
+-->
+<!DOCTYPE html>
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title> Reference</title>
+<style>
+	* {
+		font-family:system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+		--blue: rgb(80,164,252);
+		--dark-blue: #204265;
+	}
+
+	body {
+		padding: 1em;
+	}
+
+	h1 {
+		text-decoration: underline;
+		background-color: var(--blue);
+		color: white;
+		padding: 0.25em;
+		margin: 0;
+	}
+	h2 {
+		border-bottom: 0.5px solid rgba(128, 128, 128, 0.513);
+	}
+
+	a {
+		color: var(--blue);
+	}
+
+	a:hover {
+		background-color: var(--blue);
+		color: white;
+	}
+	
+	.type, .defaultval { 
+		font-weight: normal; 
+  	}
+</style> 
+</head>
+<body>
+  	<h1 class="ref_title"></h1>
+  	<div class="digest"></div>
+  	<section class="object_description">
+		<h2>Description</h2> 
+	<p></p>
+  	</section> 
+  		<section class="object_discussion"> 
+    	<h2>Discussion</h2> 
+    	<p></p>
+    	<p> is part of the Fluid Decomposition Toolkit of the FluCoMa project. For more explanations, learning material, and discussions on its musicianly uses, visit <a href="http://www.flucoma.org/">flucoma.org</a>.</p>
+  	</section>
+  	<section class="argument_section">
+    	<h2>Arguments</h2>
+ 	 </section> 
+  	<section class="attribute_section">
+    <h2>Attributes</h2>
+  	</section> 
+  	<section class="method_section"> 
+    <h2>Messages</h2>
+  </section> 
+  <section class="seealso"> 
+    <h2>See Also</h2> 
+  </section> 
+</body>
+</html>


### PR DESCRIPTION
This adds support for a folder of "local documentation" to be included in the installation target.

This means objects specific to PureData (fluid.ls2text etc.) can be documented outside the constraints of flucoma-docs.
