### PR TITLE
replace `set-output` with environment file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
           path: release-packaging/FluCoMa-PD-Linux.tar.gz
           
       - id: get-version
-        run: echo "::set-output name=version::$(cat flucoma.version.rc)"
+        run: echo "version=$(cat flucoma.version.rc)" >> $GITHUB_OUTPUT
         working-directory: build/_deps/flucoma-core-src
   
   release:


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/