### PR TITLE
EOL `.gitattributes` normalisation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,15 @@
+* text=auto
+
+*.cpp text
+*.gitignore text
+*.h text
+*.md text
+*.cmake text
+*.yml text
+*.c text
+*.txt text
+*.hpp text
+*.html text
+*.pd text
+
+*.png binary


### PR DESCRIPTION
EOL standardisation with .gitattributes to fix issues with versions of Git before 2.10 allowed automatic EOL conversion.