### PR TITLE
update flucoma core includes

### DIFF
--- a/include/FluidPDWrapper.hpp
+++ b/include/FluidPDWrapper.hpp
@@ -12,16 +12,16 @@ under the European Union’s Horizon 2020 research and innovation programme
 
 #include "PDBufferAdaptor.hpp"
 
-#include <FluidVersion.hpp>
+#include <flucoma/FluidVersion.hpp>
 
-#include <clients/common/FluidBaseClient.hpp>
-#include <clients/common/FluidNRTClientWrapper.hpp>
-#include <clients/common/OfflineClient.hpp>
-#include <clients/common/ParameterSet.hpp>
-#include <clients/common/ParameterTypes.hpp>
-#include <clients/nrt/FluidSharedInstanceAdaptor.hpp>
+#include <flucoma/clients/common/FluidBaseClient.hpp>
+#include <flucoma/clients/common/FluidNRTClientWrapper.hpp>
+#include <flucoma/clients/common/OfflineClient.hpp>
+#include <flucoma/clients/common/ParameterSet.hpp>
+#include <flucoma/clients/common/ParameterTypes.hpp>
+#include <flucoma/clients/nrt/FluidSharedInstanceAdaptor.hpp>
 
-#include <data/FluidMemory.hpp>
+#include <flucoma/data/FluidMemory.hpp>
 
 #include <m_pd.h>
 

--- a/include/PDBufferAdaptor.hpp
+++ b/include/PDBufferAdaptor.hpp
@@ -10,9 +10,9 @@ under the European Union’s Horizon 2020 research and innovation programme
 
 #pragma once
 
-#include <clients/common/BufferAdaptor.hpp>
-#include <clients/common/Result.hpp>
-#include <data/FluidTensor.hpp>
+#include <flucoma/clients/common/BufferAdaptor.hpp>
+#include <flucoma/clients/common/Result.hpp>
+#include <flucoma/data/FluidTensor.hpp>
 #include <atomic>
 #include <string_view> 
 


### PR DESCRIPTION
adjusts `#includes` of flucoma-core headers for the correspondingly named PR branch on core: https://github.com/flucoma/flucoma-core/pull/297