### PR TITLE
upload nightly to deken, manual upload setting for release

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -37,6 +37,15 @@ jobs:
           name: macbuild
           path: release-packaging/FluCoMa-PD-Mac-nightly.dmg
 
+      # additional upload to avoid dmg unpacking for deken
+      - name: archive mac folder for deken
+        run: tar -czf FluCoMa-PD-Mac-nightly.tar.gz -C release-packaging FluidCorpusManipulation
+
+      - uses: actions/upload-artifact@v4.3.6
+        with:
+          name: macdeken
+          path: FluCoMa-PD-Mac-nightly.tar.gz
+
   winbuild:
     runs-on: windows-latest
     steps:
@@ -57,6 +66,8 @@ jobs:
 
   linuxbuild:
     runs-on: ubuntu-22.04
+    outputs:
+      version: ${{ steps.get-version.outputs.version }}
     steps:
       - uses: actions/checkout@v3
       - uses: flucoma/actions/env@main 
@@ -72,6 +83,10 @@ jobs:
         with:
           name: linuxbuild 
           path: release-packaging/FluCoMa-PD-Linux-x64-nightly.tar.gz
+          
+      - id: get-version
+        run: echo "version=$(cat flucoma.version.rc)-nightly" >> $GITHUB_OUTPUT
+        working-directory: build/_deps/flucoma-core-src
   
   release:
     runs-on: ubuntu-22.04
@@ -112,3 +127,14 @@ jobs:
           prerelease: true
           draft: false
           allowUpdates: true
+
+  deken:
+    runs-on: ubuntu-22.04
+    needs: [macbuild, winbuild, linuxbuild]
+    steps:
+      - uses: flucoma/actions/deken@v6
+        with:
+          version: ${{ needs.linuxbuild.outputs.version }}
+          deken_username: ${{ secrets.DEKEN_USERNAME }}
+          deken_password: ${{ secrets.DEKEN_PASSWORD }}
+          upload: 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,12 @@
 name: release
 on:
   workflow_dispatch:
+    inputs:
+      upload_to_deken:
+        description: 'Upload to deken'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   macbuild:
@@ -129,3 +135,4 @@ jobs:
           version: ${{ needs.linuxbuild.outputs.version }}
           deken_username: ${{ secrets.DEKEN_USERNAME }}
           deken_password: ${{ secrets.DEKEN_PASSWORD }}
+          upload: ${{ inputs.upload_to_deken }}


### PR DESCRIPTION
this removes the deken upload logic for `release` runs and just expects the checkbox in the manually dispatched run (seems more elegant and logical anyway):

<img width="329" height="269" alt="github release run dialog" src="https://github.com/user-attachments/assets/4888b428-6d4b-43f8-a29e-b8d73ee834be" />

besides that (and more importantly), `nightly` builds are also uploaded to deken - as suggested in https://github.com/flucoma/flucoma-pd/pull/111#issuecomment-3674136264. the version is derived the same way as for releases, but an additional `-nightly` suffix is added. the result looks like this (these were my test runs and i removed the packages again):

<img width="559" height="390" alt="deken with flucoma result" src="https://github.com/user-attachments/assets/a4bc7ea7-06ed-4a0f-90c4-975f79776dea" />

this works pretty well; the only issue that i see is that users will probably install the nightly version by default - the deken app has preference toggles to only display the latest version and only for the system architecture. with these set, the result looks like this (but it's obviously exactly the same for Gem snapshots):

<img width="570" height="388" alt="deken with flucoma result - only nightly" src="https://github.com/user-attachments/assets/762dd865-e5eb-49d0-8194-2457ad55f1da" />

to properly run, this requires https://github.com/flucoma/actions/pull/8 and a `v6` tag on the actions side.